### PR TITLE
Update responsive-image.js

### DIFF
--- a/src/morlock/core/responsive-image.js
+++ b/src/morlock/core/responsive-image.js
@@ -143,12 +143,20 @@ function loadImageForBreakpoint(image, s) {
     setImage(image, alreadyLoaded);
   } else {
     var img = new Image();
+    var path = getPath(image, s);
+    
     img.onload = function() {
       image.loadedSizes[s] = img;
       setImage(image, img);
     };
 
-    img.src = getPath(image, s);
+    img.onerror = function() {
+      if (image.hasRetina) {
+        img.src = path.replace('@2x', '');
+      }
+    };
+
+    img.src = path;
   }
 }
 


### PR DESCRIPTION
If a responsive image is said to have retina assets, but does not at a particular breakpoint, on error it will fallback to the non-retina image at that breakpoint.
