### PR TITLE
Fix Infinite Load Bug

### DIFF
--- a/core/responsive-image.js
+++ b/core/responsive-image.js
@@ -23,6 +23,7 @@ function ResponsiveImage() {
   this.knownDimensions = null;
   this.hasLoaded = false;
   this.hasRunOnce = false;
+  this.hasLoadedFallback = false;
 }
 
 function create(imageMap) {
@@ -197,14 +198,22 @@ function loadImageForBreakpoint(image, s) {
 
     // If requesting retina fails
     img.onerror = function() {
-      if (image.hasRetina) {
-        img.src = image.getPath(image, s, false);
+      if (image.hasRetina && !image.hasLoadedFallback) {
+        image.hasLoadedFallback = true;
+        var path = image.getPath(image, s, false);
+        if (path) {
+          img.src = path;
+        }
       } else {
         image.trigger('error', img);
       }
     };
+    
+    var path = image.getPath(image, s, image.hasRetina);
 
-    img.src = image.getPath(image, s, image.hasRetina);
+    if (path) {
+      img.src = path;
+    }
   }
 }
 


### PR DESCRIPTION
I came across a nasty bug that only happens when you are missing both retina and normal images, but would trigger an infinite failing load loop. In the `onerror` image load handler for retina images, it falls back to loading the non-retina version, but if that one fails as well, it hits the `onerror` handler again, over and over.

The fix: I added a flag `hasLoadedFallback` (there might be a better name for this) to indicate whether the fallback, non-retina image has been attempted to be loaded or not, which is checked in the load error handler.

I also added a check for the result of `getPath` before blindly passing it to the `src` attribute to that if falsy values are returned nothing is loaded.
